### PR TITLE
Tool improvements

### DIFF
--- a/boca.py
+++ b/boca.py
@@ -26,7 +26,7 @@ def boca_zip(boca_folder: str) -> None:
     zip_filename = os.path.basename(boca_folder)+'.zip'
     p = subprocess.run('zip'+' -r ' + zip_filename + ' . ', shell=True,
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-    check_subprocess_output(p, "Error ziping BOCAfile.")
+    check_subprocess_output(p, "Error ziping BOCA file.")
     os.rename(zip_filename, os.path.join('..', zip_filename))
     os.chdir(old_cwd)
 

--- a/build.py
+++ b/build.py
@@ -104,10 +104,10 @@ if __name__ == "__main__":
     if not args.problem_id:
         parser.error(args.mode + ' mode requires a problem id. Usage: ' +
                      sys.argv[0] + ' ' + args.mode + ' <problem ID>')
+    instance_paths(args.problem_id)
     if args.mode != 'init':
         verify_path(args.problem_id)
 
-    instance_paths(args.problem_id)
     if (args.mode == 'init'):
         info_log('Initializing problem ' + args.problem_id)
         init(args.interactive)

--- a/checker.py
+++ b/checker.py
@@ -171,10 +171,10 @@ def run_checker(ans: str, inf: str, ouf: str) -> tuple:
     checker_file: str = os.path.join(
         Paths().get_problem_dir(), 'bin/checker')
     if (not os.path.isfile(inf)):
-        error_log('Input' + fname + 'not available')
+        error_log('Input ' + fname + ' not available')
         sys.exit(1)
     if (not os.path.isfile(ans)):
-        error_log('Answer' + fname + 'not available')
+        error_log('Answer ' + fname + ' not available')
         sys.exit(1)
     command = [checker_file, inf, ouf, ans]
     p = subprocess.run(command, stdout=subprocess.PIPE,

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 DEFAULT_PDF_OPTIONS = {
     'display_author': True,
-    'problem_label': ''
+    'problem_label': '',
+    'event': False
 }
 
 

--- a/contest.py
+++ b/contest.py
@@ -114,11 +114,10 @@ if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
 
-    for problem in args.problem_path:
-        verify_problem(problem)
-
-    os.makedirs(args.contest_folder, exist_ok=True)
     instance_paths(args.problem_path, args.contest_folder)
+    for problem in args.problem_path:
+            verify_problem(problem)
+    os.makedirs(args.contest_folder, exist_ok=True)
 
     if (args.mode == 'build' and args.boca):
         build_boca_packages()

--- a/contest.py
+++ b/contest.py
@@ -44,7 +44,8 @@ def build_contest_pdf() -> None:
     for i, folder in enumerate(problem_folder_l):
         label = convert_idx_to_string(i)
         options = {'display_author': False,
-                   'problem_label': label}
+                   'problem_label': label,
+                   'event': True}
         build_pdf(folder, output_folder, options)
         basename = os.path.basename(folder)
         problem_pdf_l.append(os.path.join(output_folder, basename+'.pdf'))
@@ -80,7 +81,8 @@ def build_boca_packages() -> None:
     for i, folder in enumerate(problem_folder_l):
         label = convert_idx_to_string(i)
         options = {'display_author': False,
-                   'problem_label': label}
+                   'problem_label': label,
+                   'event': True}
         # Build PDF and move it to contest folder
         build_pdf(folder, folder, options)
         boca_pack(folder)
@@ -90,24 +92,32 @@ def build_boca_packages() -> None:
         shutil.copy(boca_file_path, boca_file)
 
 
-def verify_problem(problem: str) -> None:
+def verify_problem(problem: str, mode: str) -> None:
     """Check if the problem is ready to be used"""
     verify_path(problem)
     verify_path(os.path.join(problem, 'statement'))
 
     # Verify I/O for statements
-    if args.mode == 'genpdf':
+    if mode == 'genpdf':
         verify_path(os.path.join(problem, 'input'))
         verify_path(os.path.join(problem, 'output'))
-
+        return
+    
+    tool_directory = os.path.dirname(os.path.abspath(__file__))
     # Build problem if it is only initialized
-    elif args.mode == 'build' and not os.path.exists(os.path.join(problem, 'bin')):
-        info_log(f"Generating BOCA package for {problem} problem.")
-        command = ['python3', os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                           'convert.py'), 'convert_to', 'boca', problem]
+    if not os.path.exists(os.path.join(problem, 'bin')):
+        info_log(f"Building {problem} problem.")
+        command = ['python3', os.path.join(tool_directory, 'build.py'), 'build', problem]
         p = subprocess.run(command, stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE, text=True)
         check_subprocess_output(p, f"Error building problem {problem}.")
+
+    if not os.path.exists(os.path.join(problem, 'boca.zip')):
+        info_log(f"Generating BOCA package for problem {problem}.")
+        command = ['python3', os.path.join(tool_directory,'convert.py'), 'convert_to', 'boca', problem]
+        p = subprocess.run(command, stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE, text=True)
+        check_subprocess_output(p, f"Error generating BOCA package for problem {problem}.")
 
 
 if __name__ == '__main__':
@@ -116,7 +126,7 @@ if __name__ == '__main__':
 
     instance_paths(args.problem_path, args.contest_folder)
     for problem in args.problem_path:
-            verify_problem(problem)
+            verify_problem(problem, args.mode)
     os.makedirs(args.contest_folder, exist_ok=True)
 
     if (args.mode == 'build' and args.boca):

--- a/jsonutils.py
+++ b/jsonutils.py
@@ -17,7 +17,7 @@ def parse_json(json_file: str) -> dict:
     json_data = {}
 
     if not os.path.isfile(json_file):
-        error_log(os.path.basename(json_file), 'does not exists.')
+        error_log(os.path.basename(json_file) + ' does not exist.')
         sys.exit(1)
 
     with open(json_file) as f:

--- a/latexutils.py
+++ b/latexutils.py
@@ -91,7 +91,9 @@ def print_to_latex(problem_folder: str, options=config.DEFAULT_PDF_OPTIONS):
     info_log(f"Creating {os.path.basename(tex_filepath)}")
     with open(tex_filepath, 'w') as f_out:
         print("\\documentclass{maratona}", file=f_out)
-        print("\\begin{document}\n", file=f_out)
+        print("\\begin{document}", file=f_out)
+        if options['event']:
+            print("\\lhead{" + problem_metadata['problem']['event'] + "}\n", file=f_out)
         if (options['display_author']):
             print("\\begin{ProblemaAutor}{" + options['problem_label']
                   + "}{" + problem_metadata["problem"]["title"] + "}{" +

--- a/legacy_converter.py
+++ b/legacy_converter.py
@@ -142,8 +142,8 @@ if __name__ == '__main__':
     parser = create_parser()
     args = parser.parse_args()
 
-    verify_path(args.problem_dir)
     instance_paths(args.problem_dir)
+    verify_path(args.problem_dir)
 
     convert_problem()
 

--- a/logger.py
+++ b/logger.py
@@ -43,9 +43,9 @@ def info_log(text: str) -> None:
         text: The information to be logged.
     """
     tool = logging.getLogger('tool')
-    text = text.rstrip()
-    if text is not None and text != '':
-        tool.info(text)
+    info = get_string(text)
+    if len(info) > 0:
+        tool.info(info)
         print(text)
 
 
@@ -56,20 +56,35 @@ def debug_log(text: str) -> None:
         text: The debug information to be logged.
     """
     debug = logging.getLogger('debug')
-    if text is not None and text.rstrip() != '':
-        debug.debug(text.rstrip())
+    info = get_string(text)
+    if len(info) > 0:
+        debug.info(info)
 
 
-def error_log(text: str, print_text: bool = True) -> None:
+def error_log(text: str) -> None:
     """Logs errors that occur during tool execution.
 
     Args:
         text: The error information to be logged.
     """
     tool = logging.getLogger('tool')
-    text = text.rstrip()
-    if text is not None and text != '':
-        tool.error(text)
-        if print_text:
-            print(text)
-        
+    info = get_string(text)
+    if len(info) > 0:
+        tool.error(info)
+        print(text)
+
+
+def get_string(x):
+    """Converts x to string.
+
+    Args:
+        x: Text to be converted to string.
+
+    Returns:
+        The string representation of x.
+    """
+    try:
+        x = str(x)
+        return x.rstrip()
+    except:
+        return ""

--- a/polygon_connection.py
+++ b/polygon_connection.py
@@ -19,7 +19,7 @@ from jsonutils import parse_json, write_to_json
 from logger import debug_log, error_log, info_log
 from metadata import Paths
 from toolchain import get_manual_tests
-from utils import convert_to_bytes, generate_tmp_directory, verify_path
+from utils import convert_to_bytes, verify_path
 
 URL = 'https://polygon.codeforces.com/api/'
 RETRIES = 3
@@ -339,7 +339,7 @@ def print_ordered_requests(q: multiprocessing.Queue) -> None:
         q: Queue with the requests.
         max_indice: Maximum indice of the requests.
     """
-    tmp_folder = os.path.join(generate_tmp_directory(), 'scripts')
+    tmp_folder = os.path.join(Paths().get_tmp_output_dir(), 'scripts')
     os.makedirs(tmp_folder, exist_ok=True)
     indexes: list = [os.path.basename(f) for f in get_manual_tests(tmp_folder)]
     indexes.sort(key=custom_key)

--- a/polygon_converter.py
+++ b/polygon_converter.py
@@ -279,9 +279,9 @@ def init_problem(interactive: bool) -> None:
         os.remove(os.path.join(problem_folder, 'statement', 'interactor.tex'))
 
 
-def write_statement(package_data: dict, interactive: bool) -> None:
+def copy_statement_files(package_data: dict, interactive: bool, language=DEFAULT_LANGUAGE) -> None:
     """Write statement files in the problem folder."""
-    info_log("Writing statement files.")
+    info_log("Copying statement files.")
     problem_folder = Paths().get_problem_dir()
     statement_dir = os.path.join(problem_folder, 'statement')
 
@@ -299,6 +299,15 @@ def write_statement(package_data: dict, interactive: bool) -> None:
     if interactive:
         with open(statement_files[5], 'w') as f:
             f.writelines(package_data['interaction'])
+    
+    package_folder = os.path.join(
+        Paths().get_output_dir(), 'statement-sections', language)
+    ignored_extensions = {'.tex', '.log'}
+    ignored_prefixes = {'example'}
+    for f in os.listdir(package_folder):
+        if not any(f.endswith(ext) for ext in ignored_extensions) and not any(f.startswith(prefix) for prefix in ignored_prefixes):
+            file_path = os.path.join(package_folder, f)
+            shutil.copy(file_path, os.path.join(problem_folder, f))
 
 
 def get_package_data(interactive: bool) -> dict:
@@ -495,7 +504,7 @@ def convert_problem(local: bool, problem_id: Optional[str] = '') -> None:
             copy_interactive_files()
 
     copy_generator(xml_data['script'])
-    write_statement(package_data, interactive)
+    copy_statement_files(package_data, interactive)
     update_problem_metadata(''.join(package_data['title']),
                             xml_data['solutions'], interactive, problem_id)
     # Clean up temporary package folder

--- a/polygon_converter.py
+++ b/polygon_converter.py
@@ -427,6 +427,7 @@ def update_problem_metadata(title: str, solutions: dict, interactive: bool, prob
         interactive: Whether the problem is interactive.
         problem_id: Problem ID.
     """
+    info_log("Updating problem metadata.")
     package_folder = Paths().get_output_dir()
     problem_folder = Paths().get_problem_dir()
 
@@ -511,8 +512,8 @@ def get_polygon_problem(problem_folder: str, problem_id: str, local: Optional[bo
         problem_id: The ID of the problem to download (default None).
     """
     if local:
-        verify_path(local)
         instance_paths(problem_folder, problem_id)
+        verify_path(local)
     else:
         instance_paths(problem_folder, os.path.join(
             problem_folder, 'temp_package'))

--- a/polygon_submitter.py
+++ b/polygon_submitter.py
@@ -14,6 +14,7 @@ LANGUAGE = 'english'
 ENCODING = 'utf-8'
 TESTSET = 'tests'
 VERIFY_IO_STATEMENT = True
+IMAGE_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'svg', 'bmp', 'ico'}
 
 
 def update_info(problem_metadata: dict) -> tuple:
@@ -98,17 +99,20 @@ def save_statement_resources() -> List[Tuple[str, dict]]:
         A list of tuples, where each tuple contains the method and the 
         parameters for the request.
     """
-    statement_dir: str = os.path.join(
-        Paths().get_problem_dir(), 'statement')
+    problem_dir: str = os.path.join(Paths().get_problem_dir())
 
     parameters_list = []
-    for file in os.listdir(statement_dir):
-        if file.endswith('.tex'):
+    for file_name in os.listdir(problem_dir):
+        filepath = os.path.join(problem_dir, file_name)
+        if os.path.isdir(filepath):
             continue
-        with open(os.path.join(statement_dir, file), 'rb') as f:
-            file_content = b''.join(f.readlines())
+        _, extension = os.path.splitext(file_name)
+        if extension.lower()[1:] not in IMAGE_EXTENSIONS:
+            continue
+        with open(filepath, 'rb') as file:
+            file_content = file.read()
         params = {
-            'name': file,
+            'name': file_name,
             'file': file_content
         }
         parameters_list.append(('problem.saveStatementResource', params))

--- a/polygon_submitter.py
+++ b/polygon_submitter.py
@@ -8,8 +8,7 @@ from logger import error_log, info_log
 from metadata import Paths
 from polygon_connection import check_polygon_id, submit_requests_list
 from toolchain import generate_inputs, get_manual_tests
-from utils import (check_problem_metadata, generate_tmp_directory,
-                   instance_paths, verify_path)
+from utils import check_problem_metadata, instance_paths, verify_path
 
 LANGUAGE = 'english'
 ENCODING = 'utf-8'
@@ -454,7 +453,7 @@ def get_requests_list() -> List[Tuple[str, dict]]:
     problem_metadata = parse_json(path_json)
     check_problem_metadata(problem_metadata)
 
-    tmp_folder = os.path.join(generate_tmp_directory(), 'scripts')
+    tmp_folder = os.path.join(Paths().get_tmp_output_dir(), 'scripts')
     generate_inputs(move=False, output_folder=tmp_folder)
 
     requests_list = []
@@ -491,8 +490,8 @@ def send_to_polygon(problem_folder: str, problem_id: Union[str, None]) -> None:
         problem_folder: Path to the problem folder.
         problem_id: ID of the Polygon problem.
     """
-    verify_path(problem_folder)
     instance_paths(problem_folder)
+    verify_path(problem_folder)
     problem_id = check_polygon_id(problem_id)
 
     requests_list: List[Tuple[str, dict]] = get_requests_list()

--- a/sqtpm.py
+++ b/sqtpm.py
@@ -7,8 +7,7 @@ from jsonutils import parse_json
 from logger import error_log, info_log
 from metadata import Paths
 from toolchain import generate_inputs, get_manual_tests
-from utils import (check_problem_metadata, generate_tmp_directory,
-                   instance_paths, verify_path)
+from utils import check_problem_metadata, instance_paths, verify_path
 
 
 def create_config(showcases: str, memory_limit: int, cputime: int) -> None:
@@ -142,7 +141,7 @@ def copy_generator_script() -> None:
 def copy_manual_tests() -> None:
     """Move manual tests to SQTPM folder."""
     output_folder = Paths().get_output_dir()
-    tmp_folder = os.path.join(generate_tmp_directory(), 'scripts')
+    tmp_folder = os.path.join(Paths().get_tmp_output_dir(), 'scripts')
 
     generate_inputs(move=False, output_folder=tmp_folder)
     manual_tests = get_manual_tests(tmp_folder)

--- a/toolchain.py
+++ b/toolchain.py
@@ -11,8 +11,7 @@ from htmlutils import print_to_html
 from jsonutils import parse_json
 from logger import debug_log, error_log, info_log
 from metadata import Paths, Problem, Solution
-from utils import (check_problem_metadata, check_subprocess_output,
-                   generate_tmp_directory, verify_path)
+from utils import check_problem_metadata, check_subprocess_output, verify_path
 
 
 def build_executables() -> None:
@@ -116,7 +115,7 @@ def validate_inputs() -> None:
             if out or err:
                 error_log(out)
                 error_log(err)
-                error_log("Failed validation on input", fname)
+                error_log("Failed validation on input " + fname)
                 sys.exit(1)
 
     # Check for equal test cases
@@ -206,7 +205,7 @@ def generate_inputs(move: bool = True, output_folder: str = '') -> None:
 
     # Create temporary folder for input tests
     if output_folder == '':
-        output_folder = os.path.join(generate_tmp_directory(), 'scripts')
+        output_folder = os.path.join(Paths().get_tmp_output_dir(), 'scripts')
     temporary_folder = os.path.join(output_folder, 'tmp')
     os.makedirs(output_folder, exist_ok=True)
     os.makedirs(temporary_folder, exist_ok=True)

--- a/toolchain.py
+++ b/toolchain.py
@@ -103,20 +103,15 @@ def validate_inputs() -> None:
     verify_path(validator_path)
 
     # Check each input file with the validator
-    input_files = [f for f in os.listdir(input_folder) if os.path.isfile(f)
-                   and not f.endswith('.interactive')]
+    input_files = [f for f in os.listdir(input_folder) if not f.endswith('.interactive')]
     input_files.sort(key=custom_key)
-    for fname in input_files:
-        with open(os.path.join(input_folder, fname)) as f:
-            p = subprocess.Popen([validator_path],
+    input_files = [os.path.join(input_folder, f) for f in input_files]
+    for fpath in input_files:
+        with open(fpath) as f:
+            p = subprocess.run([validator_path],
                                  stdin=f, stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE, text=True)
-            out, err = p.communicate()
-            if out or err:
-                error_log(out)
-                error_log(err)
-                error_log("Failed validation on input " + fname)
-                sys.exit(1)
+            check_subprocess_output(p, "Failed validation on input " + os.path.basename(fpath))
 
     # Check for equal test cases
     equal_tests = 0

--- a/utils.py
+++ b/utils.py
@@ -52,16 +52,11 @@ def check_subprocess_output(p: CompletedProcess, message: str) -> None:
         p (CompletedProcess): The completed process returned by the 'subprocess.run' function.
         message (str): The message to be printed in case of an error.
     """
+    debug_log(p.stdout)
+    debug_log(p.stderr)
     if p.returncode:
-        error_log(p.stdout, print_text=False)
-        error_log(p.stderr, print_text=False)
         error_log(message)
         sys.exit(1)
-
-    if p.stdout and p.stdout != '':
-        debug_log(p.stdout)
-    if p.stderr and p.stderr != '':
-        debug_log(p.stderr)
 
 
 def instance_paths(problem_dir: Union[str, list], output_dir: Optional[str] = '') -> None:
@@ -160,12 +155,3 @@ def generate_timestamp() -> str:
     current_time: datetime = datetime.fromtimestamp(datetime.now().timestamp())
     timestamp: str = current_time.strftime('%Y-%m-%d-%H:%M:%S')
     return timestamp
-
-
-def generate_tmp_directory() -> str:
-    """Generate path to a temporary directory.
-
-    Returns:
-        Path to the temporary directory.
-    """
-    return os.path.join('/', 'tmp', f'ds-contest-tools-{generate_timestamp()}')


### PR DESCRIPTION
## Changes
- Contest PDFs now have name of the event in the top
- Fixed duplicate error message. It occurred because the logger was not initialized when the log function was called.
- fixed the issue where the statement resource files were not being copied properly. As a result of this fix, these files are now being successfully copied to the problem folder.
- Validator fixed. Input paths were wrong, so the validator didn't receive any tests.
- Statement resource files (only images for now) in problem directory are now converted to polygon.